### PR TITLE
Add themed icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/logo_nowipass_new.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/logo_nowipass_new.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/logo_nowipass_new_background"/>
     <foreground android:drawable="@drawable/logo_nowipass_new_foreground"/>
+    <monochrome android:drawable="@drawable/logo_nowipass_new_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/logo_nowipass_new_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/logo_nowipass_new_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/logo_nowipass_new_background"/>
     <foreground android:drawable="@drawable/logo_nowipass_new_foreground"/>
+    <monochrome android:drawable="@drawable/logo_nowipass_new_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
# This PR adds support for Android 13's [*Themed Launcher Icon*](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

## Examples:

- ### Normal icon for reference

  ###
  ###   <img src="https://github.com/user-attachments/assets/4552279e-6397-4abd-ad9d-48699fc252e2" width="20%"/>

- ### Light Theme, Blue Palette
  ###
  ### <img src="https://github.com/user-attachments/assets/a026b914-2fd8-4955-98c7-ce828c61fb59" width="20%"/>

- ### Dark Theme, Blue Palette
  ###
  ###   <img src="https://github.com/user-attachments/assets/2d3d2704-703f-4e23-b3ff-6b5aba69b71c" width="20%"/>

---

#### P.S. - I didn't touch `AndroidManifest.xml`'s `android:icon` property as I assumed it was intentional that you set it to the same value as `android:roundIcon`